### PR TITLE
관리자- 콘서트 목록: 검색 기능 구현

### DIFF
--- a/concert/Oracle/concertSQL.sql
+++ b/concert/Oracle/concertSQL.sql
@@ -223,7 +223,7 @@ SELECT COUNT(*) FROM CONCERTS;
 
 -- 콘서트 목록 한 페이지의 데이터 조회 (페이지당 10개, 2페이지 조회)
 SELECT *
-FROM (SELECT ROWNUM AS RNO, C.*
+FROM (SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
            FROM (SELECT * 
                      FROM CONCERTS 
                      ORDER BY NO DESC) C)
@@ -231,27 +231,30 @@ WHERE RNO > 10 * (2 - 1) AND RNO <= 10 * 2;
 
 -- 콘서트 검색하기 - 콘서트 명 검색
 SELECT *
-FROM ( SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
-            FROM CONCERTS C
-            WHERE TITLE LIKE('%제%')
-            ORDER BY NO DESC)
-WHERE RNO> 10 * (2 - 1) AND RNO<= 10 * 2;
+FROM (SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
+           FROM (SELECT * 
+                     FROM CONCERTS 
+                     WHERE TITLE LIKE('%제%')
+                     ORDER BY NO DESC) C)
+WHERE RNO > 10 * (2 - 1) AND RNO <= 10 * 2;
 
 -- 콘서트 검색하기 - 아티스트 검색
 SELECT *
-FROM ( SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
-            FROM CONCERTS C
-            WHERE ARTIST LIKE('%범준%')
-            ORDER BY NO DESC)
-WHERE RNO> 10 * (2 - 1) AND RNO<= 10 * 2;
+FROM (SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
+           FROM (SELECT * 
+                     FROM CONCERTS 
+                     WHERE ARTIST LIKE('%범준%')
+                     ORDER BY NO DESC) C)
+WHERE RNO > 10 * (2 - 1) AND RNO <= 10 * 2;
 
 -- 콘서트 검색하기 - 아티스트 & 콘서트 검색
 SELECT *
-FROM ( SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
-            FROM CONCERTS C
-            WHERE ARTIST LIKE('%범준%') OR TITLE LIKE('%범준%')
-            ORDER BY NO DESC)
-WHERE RNO> 10 * (2 - 1) AND RNO<= 10 * 2;
+FROM SELECT ROWNUM AS RNO, NO, ARTIST, TITLE, CONTENT, TO_CHAR(CDATE, 'YYYY-MM-DD'), LOCATION
+           FROM (SELECT * 
+                     FROM CONCERTS 
+                     WHERE ARTIST LIKE('%범준%') OR TITLE LIKE('%범준%')
+                     ORDER BY NO DESC) C)
+WHERE RNO > 10 * (2 - 1) AND RNO <= 10 * 2;
 
 -- 콘서트 등록하기
 INSERT INTO CONCERTS VALUES(CONCERTS_NO_SEQ.NEXTVAL, '장범준', '제목', '장범준의 월드에 오신걸 환영합니다', '2021-01-01', '서울');


### PR DESCRIPTION
concertSQL.sql
- 날짜를 나타내는 부분에서 시, 분, 초 제거
- 콘서트 검색하기 예시 SQL 추가

ConcertDAO.java
- get_concert_search_list(): 콘서트 검색 기능 구현
- 해당 필드가 존재하는지 확인해서 SQL 구문에 추가하는 방식으로 구현함

admin_concert_list.jsp
- 파라미터를 이용해 검색 카테고리를 설정하고 이를 통해 DB에서 데이터를 가져올 수 있도록 함
- 검색 카테고리는 concert 에 저장됨
- 해당 페이지를 처음 열 때에는 모든 카테고리를 설정하도록 해야함.
- 검색 카테고리가 유지되도록 설정해야함